### PR TITLE
docs(sphinx): promote graph_tools to its own tools section

### DIFF
--- a/doc/hana_ai.tools.rst
+++ b/doc/hana_ai.tools.rst
@@ -36,8 +36,6 @@ hana_ml_tools
    hana_ml_tools.dataset_prep_tools.ImportCSVToTableTool
    hana_ml_tools.dataset_prep_tools.SplitTableForForecastingTool
    hana_ml_tools.fetch_tools.FetchDataTool
-   hana_ml_tools.graph_tools.ObjectDiscoveryTool
-   hana_ml_tools.graph_tools.DataRetrievalTool
    hana_ml_tools.hdi_artifacts_tools.HDIArtifactsTool
    hana_ml_tools.intermittent_forecast_tools.IntermittentForecast
    hana_ml_tools.model_storage_tools.ListModels
@@ -52,6 +50,20 @@ hana_ml_tools
    hana_ml_tools.ts_outlier_detection_tools.TSOutlierDetection
    hana_ml_tools.ts_visualizer_tools.TimeSeriesDatasetReport
    hana_ml_tools.ts_visualizer_tools.ForecastLinePlot
+
+.. _graph_tools-label:
+
+graph_tools
+-----------
+
+Knowledge-graph-backed retrieval tools exposed on the MCP server. ``ObjectDiscoveryTool`` calls the HANA AI Core object-discovery procedure (default ``AI_OBJECT_RETRIEVAL``) to surface schemas, tables, columns, and their relationships as narrative context. ``DataRetrievalTool`` calls the paired data-retrieval procedure to fetch rows or aggregations for a natural-language question. Both tools share the ``hana_ai.retrieval`` clients and expect a HANA remote source connected to AI Core.
+
+.. autosummary::
+   :toctree: tools/
+   :template: class.rst
+
+   hana_ml_tools.graph_tools.ObjectDiscoveryTool
+   hana_ml_tools.graph_tools.DataRetrievalTool
 
 .. _df_tools-label:
 

--- a/doc/tools/hana_ai.tools.hana_ml_tools.graph_tools.DataRetrievalTool.rst
+++ b/doc/tools/hana_ai.tools.hana_ml_tools.graph_tools.DataRetrievalTool.rst
@@ -1,0 +1,14 @@
+DataRetrievalTool
+=======================================================================
+
+.. currentmodule:: hana_ai.tools.hana_ml_tools.graph_tools
+
+.. autoclass:: DataRetrievalTool
+   :members:
+   :inherited-members: BaseTool, BaseModel
+   :no-undoc-members:
+   :exclude-members: _global_mcp_servers, launch_mcp_server, mcp_servers, stop_all_mcp_servers, stop_mcp_server, from_orm, get_prompts, parse_file, parse_obj, parse_raw, schema, schema_json, to_json_not_implemented, validate
+
+.. raw:: html
+
+    <div class="clearer"></div>

--- a/doc/tools/hana_ai.tools.hana_ml_tools.graph_tools.ObjectDiscoveryTool.rst
+++ b/doc/tools/hana_ai.tools.hana_ml_tools.graph_tools.ObjectDiscoveryTool.rst
@@ -1,0 +1,14 @@
+ObjectDiscoveryTool
+=========================================================================
+
+.. currentmodule:: hana_ai.tools.hana_ml_tools.graph_tools
+
+.. autoclass:: ObjectDiscoveryTool
+   :members:
+   :inherited-members: BaseTool, BaseModel
+   :no-undoc-members:
+   :exclude-members: _global_mcp_servers, launch_mcp_server, mcp_servers, stop_all_mcp_servers, stop_mcp_server, from_orm, get_prompts, parse_file, parse_obj, parse_raw, schema, schema_json, to_json_not_implemented, validate
+
+.. raw:: html
+
+    <div class="clearer"></div>


### PR DESCRIPTION
- Split ObjectDiscoveryTool and DataRetrievalTool out of the alphabetized hana_ml_tools listing into a dedicated graph_tools section that describes what the two MCP tools do (AI Core object-discovery and data-retrieval procedures) and that they share the hana_ai.retrieval clients.
- Add the corresponding per-class rst stubs under doc/tools/ so the autosummary references resolve.